### PR TITLE
feat: add Debian package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 ## [Unreleased]
 
 ### Added
+- [chore] Add Debian package metadata
 
 ### Changed
 - [protocol] Parse JSON as 64-bit and truncate internally

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,38 @@ protoc-bin-vendored = "3"
 lto = true
 codegen-units = 1
 
+[package.metadata.deb]
+copyright = "2024, Roderick van Domburg"
+depends = "libasound2"
+section = "sound"
+priority = "optional"
+assets = [
+    [
+        "target/release/pleezer",
+        "usr/bin/",
+        "755",
+    ],
+    [
+        "README.md",
+        "usr/share/doc/pleezer/README.md",
+        "644",
+    ],
+    [
+        "LICENSE.md",
+        "usr/share/doc/pleezer/LICENSE.md",
+        "644",
+    ],
+    [
+        "secrets.toml.example",
+        "usr/share/doc/pleezer/secrets.toml.example",
+        "644",
+    ],
+]
+extended-description = """\
+A headless streaming player built around the Deezer Connect protocol. \
+Enables streaming from Deezer to any Linux system without a graphical interface, \
+making it ideal for DIY setups, server-based systems, or custom integrations."""
+
 [package.metadata.docs.rs]
 # Disable documentation build on docs.rs
 # Remove this section when ready to publish documentation


### PR DESCRIPTION
## Description

Add Debian package metadata to enable building `.deb` packages using cargo-deb. This allows for easier distribution and installation on Debian-based Linux systems.

## Related Issues

Closes #29

## Implementation Details

Added `[package.metadata.deb]` section to `Cargo.toml` with:
- Runtime dependency on `libasound2`
- Documentation files (`README.md`, `LICENSE.md`, `secrets.toml.example`)
- Extended description for package managers
- Appropriate file permissions and paths

The configuration follows Debian packaging conventions while maintaining DRY principles by reusing existing package metadata where possible.

## Testing

Built the Debian package on macOS.

Verified that:
- Package builds successfully with `cargo deb`
- Package information checks out

## Due Diligence

- [x] I have linked any related [issues or feature requests](https://github.com/roderickvd/pleezer/issues).
- [x] I have selected the appropriate labels for this pull request.
- [x] I have performed cross-platform testing if possible.
- [x] I have updated the [CHANGELOG.md](https://github.com/roderickvd/pleezer/blob/main/CHANGELOG.md) file with a summary of my changes under the "Unreleased" section.
- [x] I have kept the pull request as a draft until it is ready for review (if applicable).
- [x] I have read and understood the [Contributing guidelines](https://github.com/roderickvd/pleezer/blob/main/CONTRIBUTING.md).