### PR TITLE
fix: change device spec separator from colon to pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ### Fixed
 - [config] Hexademical base does not correlate to key length
+- [player] Use pipe separator in device specs for ALSA compatibility
 - [repo] Fix pull request template format
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Your music will start playing on the selected device.
     pleezer -d "?"
 
     # Use a specific device, formatted as:
-    # "[<host>][:<device>][:<sample rate>][:<sample format>]" (case-insensitive)
+    # "[<host>][|<device>][|<sample rate>][|<sample format>]" (case-insensitive)
     #
     # All fields are optional:
     # - If you don't specify a host, it will use the system default host.
@@ -123,13 +123,13 @@ Your music will start playing on the selected device.
     # - If you don't specify a sample rate, it will use the device default sample rate.
     # - If you don't specify a sample format, it will use the device default sample format.
     pleezer -d "CoreAudio"
-    pleezer -d "CoreAudio:Yggdrasil+"
-    pleezer -d "CoreAudio:Yggdrasil+:44100"
-    pleezer -d "CoreAudio:Yggdrasil+:44100:f32"
+    pleezer -d "CoreAudio|Yggdrasil+"
+    pleezer -d "CoreAudio|Yggdrasil+|44100"
+    pleezer -d "CoreAudio|Yggdrasil+|44100|f32"
 
-    # Some more advanced examples, showing you can omit fields as long as you include the colons:
-    pleezer -d ":yggdrasil+"    # The Yggdrasil+ device (case-insensitive)
-    pleezer -d "::44100"        # The first device to support 44100 Hz
+    # Some more advanced examples, showing you can omit fields as long as you include the pipes:
+    pleezer -d "|yggdrasil+"    # The Yggdrasil+ device (case-insensitive)
+    pleezer -d "||44100"        # The first device to support 44100 Hz
     ```
 
     Deezer streams audio at 44100 Hz exclusively. Sampling rates other than

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ struct Args {
 
     /// Select the audio output device
     ///
-    /// Format: [<host>][:<device>][:<sample rate>][:<sample format>]
+    /// Format: [<host>][|<device>][|<sample rate>][|<sample format>]
     /// Use "?" to list available devices.
     /// If omitted, uses the system default output device.
     #[arg(short, long, default_value = None, env = "PLEEZER_DEVICE")]

--- a/src/player.rs
+++ b/src/player.rs
@@ -145,10 +145,10 @@ impl Player {
     fn open_sink(device: &str) -> Result<(rodio::Sink, rodio::OutputStream)> {
         let (stream, handle) = {
             // The device string has the following format:
-            // [<host>][:<device>][:<sample rate>:<sample format>]
+            // "[<host>][|<device>][|<sample rate>][|<sample format>]" (case-insensitive)
             // From left to right, the fields are optional, but each field
             // depends on the preceding fields being specified.
-            let mut components = device.split(':');
+            let mut components = device.split('|');
 
             // The host is the first field.
             let host = match components.next() {
@@ -267,7 +267,7 @@ impl Player {
                             if let Ok(device_name) = device.name() {
                                 let max_sample_rate = config.with_max_sample_rate();
                                 let mut line = format!(
-                                    "{}:{}:{}:{}",
+                                    "{}|{}|{}|{}",
                                     host.id().name(),
                                     device_name,
                                     max_sample_rate.sample_rate().0,


### PR DESCRIPTION
## Description

Using a colon as separator in device specifications conflicted with ALSA device names that contain colons. Changed to pipe character which is less likely to appear in device names across platforms (Linux/ALSA, macOS/CoreAudio, Windows/WASAPI).

## Related Issues

Fixes #33

## Testing

Tested on macOS Ventura & Debian Bookworm.

## Due Diligence

Please confirm that you have completed the following tasks by checking the boxes:

- [x] I have linked any related [issues or feature requests](https://github.com/roderickvd/pleezer/issues).
- [x] I have selected the appropriate labels for this pull request.
- [x] I have performed cross-platform testing if possible.
- [x] I have updated the [CHANGELOG.md](https://github.com/roderickvd/pleezer/blob/main/CHANGELOG.md) file with a summary of my changes under the "Unreleased" section.
- [x] I have kept the pull request as a draft until it is ready for review (if applicable).
- [x] I have read and understood the [Contributing guidelines](https://github.com/roderickvd/pleezer/blob/main/CONTRIBUTING.md).
