### PR TITLE
fix: improve audio device enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 ### Fixed
 - [config] Hexademical base does not correlate to key length
 - [player] Use pipe separator in device specs for ALSA compatibility
+- [player] Clean up audio device enumeration output
 - [repo] Fix pull request template format
 
 ### Security


### PR DESCRIPTION
## Description

Replace range-based sample rate configs with explicit sample rates to:
- Remove duplicate ALSA device entries
- Filter out unreasonable sample rates (>384kHz)
- Remove phantom capabilities from software interfaces
- Sort output for consistent display

The enumeration now tries each standard sample rate (44.1kHz through 384kHz) explicitly rather than using ALSA's reported ranges, which could indicate support for impossible rates like 4GHz.

## Related Issues

Fixes #32 

## Implementation Details

Instead of using CPAL's range-based configuration which leads to duplicates and unrealistic sample rates, the implementation:

1. Defines a list of standard sample rates (44.1kHz to 384kHz)
2. Attempts to configure each device with each standard rate
3. Only adds configurations that the device actually supports
4. Uses a HashSet to eliminate any remaining duplicates
5. Sorts the final output for consistent display

Key changes:
```rust
const SAMPLE_RATES: [u32; 8] = [
    44100, 48000,      // CD/Professional audio
    88200, 96000,      // High resolution
    176400, 192000,    // Studio quality
    352800, 384000     // Ultra HD
];
```

The implementation tries each rate with `try_with_sample_rate()` rather than using the default range-based configs. This ensures we only report rates that are actually supported by the hardware.

## Testing

Tested on macOS Ventura & Debian Bookworm.

## Due Diligence

Please confirm that you have completed the following tasks by checking the boxes:

- [x] I have linked any related [issues or feature requests](https://github.com/roderickvd/pleezer/issues).
- [x] I have selected the appropriate labels for this pull request.
- [x] I have performed cross-platform testing if possible.
- [x] I have updated the [CHANGELOG.md](https://github.com/roderickvd/pleezer/blob/main/CHANGELOG.md) file with a summary of my changes under the "Unreleased" section.
- [x] I have kept the pull request as a draft until it is ready for review (if applicable).
- [x] I have read and understood the [Contributing guidelines](https://github.com/roderickvd/pleezer/blob/main/CONTRIBUTING.md).
