### PR TITLE
fix: Only open audio device on first playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+- [player] Fix audio device being held before playback starts
+
 ## [v0.11.1] - 2025-01-27
 
 ### Changed


### PR DESCRIPTION
## Description

Move audio device initialization from connection time to first playback to:
- Prevent unnecessarily holding audio device when not playing
- Apply initial volume when actually starting playback

## Related Issues

- Fix issue #56 where device was held too early

## Testing

Tested locally on macOS by connecting in play state, connecting in pause state, disconnecting and reconnecting.

## Due Diligence

Please confirm that you have completed the following tasks by checking the boxes:

- [x] I have linked any related [issues or feature requests](https://github.com/roderickvd/pleezer/issues).
- [x] I have selected the appropriate labels for this pull request.
- [x] I have performed cross-platform testing if possible.
- [x] I have updated the [CHANGELOG.md](https://github.com/roderickvd/pleezer/blob/main/CHANGELOG.md) file with a summary of my changes under the "Unreleased" section.
- [x] I have kept the pull request as a draft until it is ready for review (if applicable).
- [x] I have read and understood the [Contributing guidelines](https://github.com/roderickvd/pleezer/blob/main/CONTRIBUTING.md).
