### PR TITLE
fix: add network interface binding support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- [http] Support binding outgoing connections to specific network interfaces
+
 ### Fixed
+- [http] Fix connection timeouts in dual-stack network environments
 - [player] Fix audio device being held before playback starts
 
 ## [v0.11.1] - 2025-01-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+- [main] Shortened secrets file parameter to just `secrets` for consistency
+
 ### Added
 - [http] Support binding outgoing connections to specific network interfaces
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ Your music will then play through **pleezer** while being controlled from your m
 
 ### Command-Line Arguments
 
+- `-s` or `--secrets`: Specify the secrets configuration file. Defaults to `secrets.toml`. Example:
+    ```bash
+    pleezer -s /path/to/secrets.toml
+    ```
+
 - `-n` or `--name`: Set the player's name as it appears to Deezer clients. By default, it uses the system hostname. Example:
     ```bash
     pleezer --name "My Deezer Player"
@@ -247,6 +252,13 @@ Your music will then play through **pleezer** while being controlled from your m
     pleezer --no-interruptions
     ```
 
+- `--bind`: Set the address to bind outgoing connections to. Defaults to "0.0.0.0" (IPv4 any address). Can be useful in dual-stack environments or when specific routing is needed. Example:
+    ```bash
+    pleezer --bind 192.168.1.2     # Bind to specific IPv4 interface
+    pleezer --bind ::1             # Bind to IPv6 loopback
+    ```
+    **Note:** The default IPv4-only binding prevents connection timeouts that can occur in dual-stack environments when attempting IPv6 connections to Deezer's IPv4-only services.
+
 - `--hook`: Specify a script to execute when events occur (see [Hook Scripts](#hook-scripts) for details). Example:
     ```bash
     pleezer --hook /path/to/script.sh
@@ -271,9 +283,14 @@ Your music will then play through **pleezer** while being controlled from your m
 
     **Note:** This option provides only partial insight into client communications. While some messages are echoed across all websockets belonging to a user, most messages are sent on separate websockets specific to each client. For complete traffic analysis, monitoring of all websockets would be required.
 
-- `-s` or `--secrets`: Specify the secrets configuration file. Defaults to `secrets.toml`. Example:
+- `-h` or `--help`: Display help information about command-line options and exit. Example:
     ```bash
-    pleezer -s /path/to/secrets.toml
+    pleezer -h
+    ```
+
+- `--version`: Show **pleezer** version and build information, then exit. Example:
+    ```bash
+    pleezer --version
     ```
 
 - `-h` or `--help`: Display help information about command-line options and exit. Example:

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@
 //!     device_name: "My Player".to_string(),
 //!     normalization: true,
 //!     initial_volume: Some(Percentage::from_percent_f32(50.0)), // Start at 50% volume
-//!     bind: "192.168.1.2".parse().unwrap(), // Bind to specific interface
+//!     bind_address: "192.168.1.2".parse().unwrap(), // Bind to specific interface
 //!     // ... other settings ...
 //! };
 //!
@@ -168,7 +168,7 @@ pub struct Config {
     pub eavesdrop: bool,
 
     /// The address to bind for outgoing connections.
-    pub bind: IpAddr,
+    pub bind_address: IpAddr,
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 //! This module handles:
 //! * Authentication methods (email/password or ARL)
 //! * Device identification and settings
+//! * Network configuration (interface binding)
 //! * Audio configuration (volume, normalization)
 //! * Track decryption configuration
 //! * API client settings
@@ -13,13 +14,15 @@
 //! use pleezer::config::{Config, Credentials};
 //! use pleezer::arl::Arl;
 //! use pleezer::protocol::connect::Percentage;
+//! use std::net::IpAddr;
 //!
-//! // Configure with ARL authentication and initial volume
+//! // Configure with ARL authentication, initial volume, and specific network binding
 //! let config = Config {
 //!     credentials: Credentials::Arl(arl),
 //!     device_name: "My Player".to_string(),
 //!     normalization: true,
 //!     initial_volume: Some(Percentage::from_percent_f32(50.0)), // Start at 50% volume
+//!     bind: "192.168.1.2".parse().unwrap(), // Bind to specific interface
 //!     // ... other settings ...
 //! };
 //!
@@ -32,6 +35,8 @@
 //!     // ... other settings ...
 //! };
 //! ```
+
+use std::net::IpAddr;
 
 use regex_lite::Regex;
 use uuid::Uuid;
@@ -161,6 +166,9 @@ pub struct Config {
 
     /// Whether to eavesdrop on the network traffic.
     pub eavesdrop: bool,
+
+    /// The address to bind for outgoing connections.
+    pub bind: IpAddr,
 }
 
 impl Config {

--- a/src/error.rs
+++ b/src/error.rs
@@ -885,3 +885,13 @@ impl From<cookie_store::CookieError> for Error {
         }
     }
 }
+
+/// Converts IP address parsing errors to `InvalidArgument`.
+///
+/// Used when an IP address string cannot be parsed into a valid
+/// IPv4 or IPv6 address.
+impl From<std::net::AddrParseError> for Error {
+    fn from(e: std::net::AddrParseError) -> Self {
+        Self::invalid_argument(e)
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,6 +4,7 @@
 //! * Cookie-based session management for authentication
 //! * Persistent login across client restarts
 //! * Request rate limiting to respect API quotas
+//! * Network interface binding for routing control
 //! * Configurable timeouts for connections and reads
 //! * Connection keepalive for performance
 //!
@@ -21,6 +22,14 @@
 //! * Automatic request throttling
 //! * Allows bursts up to the maximum calls per interval
 //! * Requests that would exceed the limit are delayed
+//!
+//! # Network Binding
+//!
+//! Supports binding outgoing connections to specific network interfaces:
+//! * Configurable local IP address binding
+//! * Supports both IPv4 and IPv6 addresses
+//! * Default binding to IPv4 for Deezer compatibility
+//! * Useful for VPN/tunnel routing or multi-homed systems
 //!
 //! # Timeouts
 //!
@@ -175,7 +184,8 @@ impl Client {
             .connect_timeout(Self::CONNECT_TIMEOUT)
             .read_timeout(Self::READ_TIMEOUT)
             .default_headers(headers)
-            .user_agent(&config.user_agent);
+            .user_agent(&config.user_agent)
+            .local_address(config.bind);
 
         if let Some(ref jar) = cookie_jar {
             http_client = http_client.cookie_provider(Arc::clone(jar));

--- a/src/http.rs
+++ b/src/http.rs
@@ -186,7 +186,7 @@ impl Client {
             .read_timeout(Self::READ_TIMEOUT)
             .default_headers(headers)
             .user_agent(&config.user_agent)
-            .local_address(config.bind);
+            .local_address(config.bind_address);
 
         if let Some(ref jar) = cookie_jar {
             http_client = http_client.cookie_provider(Arc::clone(jar));

--- a/src/http.rs
+++ b/src/http.rs
@@ -119,17 +119,18 @@ impl Client {
     const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(60);
 
     /// Duration to wait for connection establishment.
-    const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+    ///
+    /// The timeout needs to be greater than 5 seconds to allow for
+    /// AAAA record resolution timeouts that can occur on Linux.
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
     /// Duration to wait for individual network reads.
     ///
-    /// Reads that take longer than 5 seconds will timeout to:
+    /// Reads that take longer than 2 seconds will timeout to:
     /// * Prevent blocking operations
     /// * Allow faster recovery from network issues
     /// * Maintain responsive streaming
-    ///
-    /// The timeout needs to be long enough to allow for slow hardware and network conditions.
-    const READ_TIMEOUT: Duration = Duration::from_secs(5);
+    const READ_TIMEOUT: Duration = Duration::from_secs(2);
 
     /// Content type for plain text requests.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,7 +468,7 @@ async fn run(args: Args) -> Result<ShutdownSignal> {
             bf_secret,
 
             eavesdrop: args.eavesdrop,
-            bind: args.bind.parse()?,
+            bind_address: args.bind.parse()?,
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ const MAX_BACKOFF: Duration = Duration::from_secs(10);
 /// * Authentication (secrets file)
 /// * Device identification (name, type)
 /// * Audio settings (device, normalization)
-/// * Connection behavior (interruptions)
+/// * Connection behavior (interruptions, binding)
 /// * Debug features (logging, eavesdropping)
 ///
 /// All options can be set via environment variables with
@@ -185,6 +185,15 @@ struct Args {
         env = "PLEEZER_EAVESDROP"
     )]
     eavesdrop: bool,
+
+    /// Address to bind outgoing connections to
+    ///
+    /// Defaults to "0.0.0.0" (IPv4 any address) since Deezer services are IPv4-only
+    /// Can be set to a specific IPv4 or IPv6 address to control which network interface
+    /// is used for outgoing connections, for example when using tunneling or specific
+    /// routing requirements.
+    #[arg(long, default_value = "0.0.0.0", env = "PLEEZER_BIND")]
+    bind: String,
 }
 
 /// Initialize logging system.
@@ -459,6 +468,7 @@ async fn run(args: Args) -> Result<ShutdownSignal> {
             bf_secret,
 
             eavesdrop: args.eavesdrop,
+            bind: args.bind.parse()?,
         }
     };
 


### PR DESCRIPTION
## Description

Default is IPv4-only to prevent AAAA DNS lookup timeouts since Deezer services are primarily IPv4. This fixes connection timeouts in dual-stack environments where failed IPv6 attempts would delay IPv4 connectivity.

## Related Issues

- Fixes #52

## Implementation Details

Add ability to bind outgoing connections to specific network interfaces:
- New `--bind` CLI option (defaults to 0.0.0.0)
- Configurable through `PLEEZER_BIND` env var
- Supports both IPv4 and IPv6 addresses
- Useful for VPN/tunnel routing or multi-homed systems

## Testing

Tested locally, but do not have access to dual-home environment.

## Due Diligence

Please confirm that you have completed the following tasks by checking the boxes:

- [x] I have linked any related [issues or feature requests](https://github.com/roderickvd/pleezer/issues).
- [x] I have selected the appropriate labels for this pull request.
- [x] I have performed cross-platform testing if possible.
- [x] I have updated the [CHANGELOG.md](https://github.com/roderickvd/pleezer/blob/main/CHANGELOG.md) file with a summary of my changes under the "Unreleased" section.
- [x] I have kept the pull request as a draft until it is ready for review (if applicable).
- [x] I have read and understood the [Contributing guidelines](https://github.com/roderickvd/pleezer/blob/main/CONTRIBUTING.md).
